### PR TITLE
fix: claude spawn via stdin, log streaming, and custom label support

### DIFF
--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -43,18 +43,21 @@ export async function runDaemon(repoPath: string, label?: string): Promise<void>
 
   while (running) {
     try {
-      const activesBefore = scheduler.activeSessions().size;
+      const idsBefore = new Set(scheduler.activeSessions().keys());
       await poll(board, scheduler, agent, stateManager, config, repoPath, label);
       const activesAfter = scheduler.activeSessions().size;
 
       // Log newly spawned sessions
-      if (activesAfter > activesBefore) {
-        for (const [taskId, session] of scheduler.activeSessions()) {
+      let newTasksStarted = 0;
+      for (const [taskId, session] of scheduler.activeSessions()) {
+        if (!idsBefore.has(taskId)) {
           log(`Task ${taskId} started — pid ${session.pid}`);
           log(`  log: ${session.logFile}`);
           log(`--- agent output ---`);
+          newTasksStarted++;
         }
-      } else if (activesAfter === 0) {
+      }
+      if (newTasksStarted === 0 && activesAfter === 0) {
         log(`No tasks available. Polling again in ${config.pollIntervalSeconds}s`);
       }
 


### PR DESCRIPTION
## Summary

Fixes 4 bugs found during the first real oflow run:

- **Spawn via stdin**: `claude -p --dangerously-skip-permissions` with stdin input replaces `--print <prompt>` arg, fixing YAML frontmatter being parsed as CLI flags (`error: unknown option '---'`)
- **Log streaming**: Claude stdout/stderr now piped to both `.oflow/runs/<id>/run.log` and terminal in real-time with `[task-X]` prefix
- **Custom label propagation**: `GitHubBoardAdapter.listAvailableTasks(label?)` now accepts an optional label override instead of always using `config.taskLabel`
- **Richer daemon logs**: Spawn details (PID, log file path), start/end markers, and concurrent-task fix (only newly started sessions are logged per poll cycle)

Closes #14

## Test plan

- [x] All 72 existing tests pass
- [x] New tests in `claude-code.test.ts`: verifies `-p --dangerously-skip-permissions` spawn shape and stdin write
- [x] New tests in `github.test.ts`: verifies label override is passed through
- [x] Manually verified daemon log output shows correct task start/end markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)