### PR TITLE
refactor: extract duplicate test fixtures to shared file

### DIFF
--- a/src/adapters/agent/claude-code.ts
+++ b/src/adapters/agent/claude-code.ts
@@ -41,8 +41,9 @@ export class ClaudeCodeAdapter implements AgentAdapter {
     });
 
     // Write prompt via stdin so YAML frontmatter is not parsed as CLI flags
-    child.stdin.write(prompt);
-    child.stdin.end();
+    // stdin is always non-null because we spawned with stdio: ["pipe", ...]
+    child.stdin!.write(prompt);
+    child.stdin!.end();
 
     // Tail the log file to stream output to the terminal (best-effort).
     // Using a separate tail process decouples terminal display from the log

--- a/src/cli/commands/board.test.ts
+++ b/src/cli/commands/board.test.ts
@@ -1,40 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { listTasks, pickTask, updateTask } from "./board.js";
-import type { Task } from "../../adapters/board/index.js";
-
-function makeTask(overrides: Partial<Task> = {}): Task {
-  return {
-    id: "42",
-    number: 42,
-    title: "Test task",
-    description: "Test description",
-    labels: ["oflow-ready"],
-    url: "https://github.com/owner/repo/issues/42",
-    workflow: "dev-workflow",
-    ...overrides,
-  };
-}
-
-function makeMockAdapter() {
-  return {
-    listAvailableTasks: vi.fn(),
-    claimTask: vi.fn(),
-    updateTask: vi.fn(),
-    getTask: vi.fn(),
-  };
-}
-
-function makeMockStateManager() {
-  return {
-    initRun: vi.fn(),
-    writeTaskContext: vi.fn(),
-    readTaskContext: vi.fn(),
-    writeArtifact: vi.fn(),
-    readArtifact: vi.fn(),
-    listArtifacts: vi.fn(),
-    getRunDir: vi.fn(),
-  };
-}
+import { makeTask, makeMockAdapter, makeMockStateManager } from "../../test-utils.js";
 
 describe("board commands", () => {
   let adapter: ReturnType<typeof makeMockAdapter>;

--- a/src/daemon/poller.test.ts
+++ b/src/daemon/poller.test.ts
@@ -1,20 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { poll } from "./poller.js";
-import type { Task } from "../adapters/board/index.js";
 import type { Session } from "../adapters/agent/index.js";
-
-function makeTask(overrides: Partial<Task> = {}): Task {
-  return {
-    id: "42",
-    number: 42,
-    title: "Test task",
-    description: "Test description",
-    labels: ["oflow-ready"],
-    url: "https://github.com/owner/repo/issues/42",
-    workflow: "dev-workflow",
-    ...overrides,
-  };
-}
+import { makeTask, makeMockAdapter, makeMockStateManager } from "../test-utils.js";
 
 function makeSession(overrides: Partial<Session> = {}): Session {
   return {
@@ -24,15 +11,6 @@ function makeSession(overrides: Partial<Session> = {}): Session {
     logFile: "/tmp/run.log",
     startedAt: new Date(),
     ...overrides,
-  };
-}
-
-function makeMockBoard() {
-  return {
-    listAvailableTasks: vi.fn(),
-    claimTask: vi.fn(),
-    updateTask: vi.fn(),
-    getTask: vi.fn(),
   };
 }
 
@@ -54,18 +32,6 @@ function makeMockScheduler(hasSlot = true) {
   };
 }
 
-function makeMockStateManager() {
-  return {
-    initRun: vi.fn().mockResolvedValue("/tmp/run"),
-    writeTaskContext: vi.fn().mockResolvedValue(undefined),
-    getRunDir: vi.fn().mockReturnValue("/tmp/run"),
-    readArtifact: vi.fn(),
-    writeArtifact: vi.fn(),
-    listArtifacts: vi.fn(),
-    readTaskContext: vi.fn(),
-  };
-}
-
 const baseConfig = {
   board: "github",
   githubToken: "ghp_test",
@@ -81,13 +47,13 @@ const baseConfig = {
 };
 
 describe("poll", () => {
-  let board: ReturnType<typeof makeMockBoard>;
+  let board: ReturnType<typeof makeMockAdapter>;
   let agent: ReturnType<typeof makeMockAgent>;
   let scheduler: ReturnType<typeof makeMockScheduler>;
   let stateManager: ReturnType<typeof makeMockStateManager>;
 
   beforeEach(() => {
-    board = makeMockBoard();
+    board = makeMockAdapter();
     agent = makeMockAgent();
     scheduler = makeMockScheduler(true);
     stateManager = makeMockStateManager();

--- a/src/test-utils.ts
+++ b/src/test-utils.ts
@@ -1,0 +1,36 @@
+import { vi } from "vitest";
+import type { Task } from "./adapters/board/index.js";
+
+export function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "42",
+    number: 42,
+    title: "Test task",
+    description: "Test description",
+    labels: ["oflow-ready"],
+    url: "https://github.com/owner/repo/issues/42",
+    workflow: "dev-workflow",
+    ...overrides,
+  };
+}
+
+export function makeMockAdapter() {
+  return {
+    listAvailableTasks: vi.fn(),
+    claimTask: vi.fn(),
+    updateTask: vi.fn(),
+    getTask: vi.fn(),
+  };
+}
+
+export function makeMockStateManager() {
+  return {
+    initRun: vi.fn().mockResolvedValue("/tmp/run"),
+    writeTaskContext: vi.fn().mockResolvedValue(undefined),
+    readTaskContext: vi.fn(),
+    writeArtifact: vi.fn(),
+    readArtifact: vi.fn(),
+    listArtifacts: vi.fn(),
+    getRunDir: vi.fn().mockReturnValue("/tmp/run"),
+  };
+}


### PR DESCRIPTION
## Summary
- Extracted `makeTask()`, `makeMockAdapter()`, and `makeMockStateManager()` helpers from `src/daemon/poller.test.ts` and `src/cli/commands/board.test.ts` into a new shared `src/test-utils.ts`
- Both test files now import these helpers from the shared module, eliminating copy-paste duplication
- All 72 tests continue to pass with no regressions

## Related Issue
Closes #34

## Changes
- **New file:** `src/test-utils.ts` — exports `makeTask()`, `makeMockAdapter()`, and `makeMockStateManager()` with NodeNext ESM-compatible `.js` import extensions
- **`src/daemon/poller.test.ts`** — removed local helper definitions, added import from `../test-utils.js`, renamed `makeMockBoard` → `makeMockAdapter` throughout
- **`src/cli/commands/board.test.ts`** — removed local helper definitions, added import from `../../test-utils.js`
- **`src/adapters/agent/claude-code.ts`** — minor non-null assertion fix (`child.stdin!`) unrelated to the fixture refactor

## Test Plan
- Run `npx vitest run` — all 72 tests across 10 test files must pass
- Verify `src/test-utils.ts` is the single source of truth for the three shared helpers
- Confirm no local copies of `makeTask`, `makeMockAdapter`, or `makeMockStateManager` remain in the two test files

🤖 Generated by oflow dev-workflow