### PR TITLE
fix: session stuck in loop when oflow-in-progress label already removed

### DIFF
--- a/src/adapters/board/github.test.ts
+++ b/src/adapters/board/github.test.ts
@@ -232,6 +232,25 @@ describe("GitHubBoardAdapter", () => {
         expect.objectContaining({ name: "oflow-in-progress" })
       );
     });
+
+    it("does not throw when removeLabel returns 404 (label already removed)", async () => {
+      mock.issues.addLabels.mockResolvedValue({});
+      mock.issues.removeLabel.mockRejectedValue(
+        Object.assign(new Error("Label does not exist"), { status: 404 })
+      );
+      mock.issues.createComment.mockResolvedValue({});
+
+      await expect(adapter.updateTask("42", { status: "done" })).resolves.not.toThrow();
+    });
+
+    it("re-throws non-404 errors from removeLabel", async () => {
+      mock.issues.addLabels.mockResolvedValue({});
+      mock.issues.removeLabel.mockRejectedValue(
+        Object.assign(new Error("Forbidden"), { status: 403 })
+      );
+
+      await expect(adapter.updateTask("42", { status: "done" })).rejects.toThrow("Forbidden");
+    });
   });
 
   describe("getTask", () => {

--- a/src/adapters/board/github.ts
+++ b/src/adapters/board/github.ts
@@ -124,12 +124,17 @@ export class GitHubBoardAdapter implements BoardAdapter {
       }
 
       if (removeLabel) {
-        await this.octokit.issues.removeLabel({
-          owner: this.owner,
-          repo: this.repo,
-          issue_number: issueNumber,
-          name: removeLabel,
-        });
+        try {
+          await this.octokit.issues.removeLabel({
+            owner: this.owner,
+            repo: this.repo,
+            issue_number: issueNumber,
+            name: removeLabel,
+          });
+        } catch (err) {
+          // Label already absent is fine — removal is idempotent
+          if ((err as { status?: number }).status !== 404) throw err;
+        }
       }
     }
 

--- a/src/cli/commands/run.test.ts
+++ b/src/cli/commands/run.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach, type MockInstance } from "vitest";
 import { runDaemon } from "./run.js";
 import * as poller from "../../daemon/poller.js";
+import { Scheduler } from "../../daemon/scheduler.js";
+import { GitHubBoardAdapter } from "../../adapters/board/github.js";
+import { ClaudeCodeAdapter } from "../../adapters/agent/claude-code.js";
 
 vi.mock("../../config/loader.js", () => ({
   loadConfig: () => ({
@@ -96,5 +99,56 @@ describe("runDaemon", () => {
       "/repo",
       "my-label"
     );
+  });
+
+  it("removes session from scheduler even when updateTask throws", async () => {
+    const session = {
+      id: "session-1",
+      taskId: "42",
+      pid: 12345,
+      logFile: "/tmp/run.log",
+      startedAt: new Date(),
+    };
+
+    const removeSession = vi.fn().mockImplementation(() => {
+      // Stop the daemon after the session is cleaned up so the test doesn't hang
+      process.emit("SIGINT" as any);
+    });
+
+    // activeSessions is called 4 times per loop iteration:
+    // 1. idsBefore snapshot, 2. activesAfter size, 3. new-sessions log loop,
+    // 4. completed-sessions check — only the 4th call should return the session
+    let activeSessionsCallCount = 0;
+    (Scheduler as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      hasSlot: vi.fn().mockReturnValue(false),
+      addSession: vi.fn(),
+      removeSession,
+      activeSessions: vi.fn().mockImplementation(() => {
+        activeSessionsCallCount++;
+        return activeSessionsCallCount === 4
+          ? new Map([["42", session]])
+          : new Map();
+      }),
+    }));
+
+    (ClaudeCodeAdapter as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      spawn: vi.fn(),
+      getStatus: vi.fn().mockResolvedValue("completed"),
+    }));
+
+    (GitHubBoardAdapter as ReturnType<typeof vi.fn>).mockImplementationOnce(() => ({
+      listAvailableTasks: vi.fn().mockResolvedValue([]),
+      claimTask: vi.fn(),
+      updateTask: vi.fn().mockRejectedValue(
+        Object.assign(new Error("Label does not exist"), { status: 404 })
+      ),
+      getTask: vi.fn(),
+    }));
+
+    pollSpy.mockResolvedValue(undefined);
+
+    await runDaemon("/repo");
+
+    expect(removeSession).toHaveBeenCalledWith("42");
   });
 });

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -71,11 +71,14 @@ export async function runDaemon(repoPath: string, label?: string): Promise<void>
           if (status === "failed") {
             log(`  logs: ${session.logFile}`);
           }
-          await board.updateTask(taskId, {
-            status: status === "completed" ? "done" : "failed",
-            comment: `oflow: task ${status} in ${duration}s`,
-          });
-          scheduler.removeSession(taskId);
+          try {
+            await board.updateTask(taskId, {
+              status: status === "completed" ? "done" : "failed",
+              comment: `oflow: task ${status} in ${duration}s`,
+            });
+          } finally {
+            scheduler.removeSession(taskId);
+          }
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Problem

When a task agent removes the \`oflow-in-progress\` label itself during its run, the daemon's post-completion call to \`board.updateTask\` throws a 404 from GitHub's \`removeLabel\` API. Because \`scheduler.removeSession\` was called only after \`updateTask\`, the session was never removed. Every subsequent poll cycle found the same "completed" session, tried to update it, failed, and looped forever:

\`\`\`
Task 34 completed in 1320s
Poll error: Label does not exist   ← updateTask threw, removeSession skipped
Task 34 completed in 1381s         ← same session, next cycle
Poll error: Label does not exist
...
\`\`\`

## Fix

Two complementary changes:

**\`src/adapters/board/github.ts\`** — swallow 404 from \`removeLabel\`
Label removal is idempotent: a label that's already absent is the desired state. A 404 here is not an error. Non-404 errors are still re-thrown.

**\`src/cli/commands/run.ts\`** — \`try/finally\` around \`updateTask\`
\`scheduler.removeSession\` is now called in a \`finally\` block so it fires regardless of whether \`updateTask\` succeeds or throws. Defensive against any future \`updateTask\` failures, not just 404s.

## Tests

- \`github.test.ts\`: \`updateTask\` does not throw when \`removeLabel\` returns 404; non-404 errors are still propagated
- \`run.test.ts\`: \`removeSession\` is called even when \`updateTask\` throws (the stuck-loop scenario)

All 75 tests pass.