### PR TITLE
chore: remove .worktrees/mvp worktree

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsx src/cli/index.ts",
-    "test": "vitest run --exclude '.worktrees/**'",
+    "test": "vitest run",
     "lint": "eslint src --ext .ts"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- Removed the stale `.worktrees/mvp` git worktree (the `mvp/m0-m4` branch was already merged into main)
- Removed the leftover empty `.worktrees/` directory
- Removed the now-unnecessary `--exclude '.worktrees/**'` flag from the `test` script in `package.json`

## Related Issue
Closes #30

## Changes
- `git worktree remove --force .worktrees/mvp` to deregister and delete the stale worktree
- `rmdir .worktrees/` to clean up the empty parent directory
- `package.json`: simplified test script from `"vitest run --exclude '.worktrees/**'"` to `"vitest run"`

## Test Plan
- Run `npm test` — all 75 tests across 10 test files pass with the simplified test command

🤖 Generated by oflow dev-workflow