### PR TITLE
fix: align child.unref() usage between ClaudeCodeAdapter and OpencodeAdapter

### DIFF
--- a/src/adapters/agent/opencode.ts
+++ b/src/adapters/agent/opencode.ts
@@ -43,8 +43,6 @@ export class OpencodeAdapter implements AgentAdapter {
     if (child.stdout) child.stdout.pipe(logStream);
     if (child.stderr) child.stderr.pipe(logStream);
 
-    child.unref();
-
     const session: Session = {
       id: randomUUID(),
       taskId,


### PR DESCRIPTION
## Summary

- Removes `child.unref()` from `OpencodeAdapter` so both adapters hold the event loop open for the child process lifetime, matching the behavior of `ClaudeCodeAdapter`

Closes #28

## Files Changed

- `src/adapters/agent/opencode.ts`

## Test Plan

- [x] 75 tests pass