### PR TITLE
chore: merge split fs/promises imports in opencode.ts

### DIFF
--- a/src/adapters/agent/opencode.ts
+++ b/src/adapters/agent/opencode.ts
@@ -1,6 +1,5 @@
 import { spawn } from "child_process";
-import { readFile } from "fs/promises";
-import { open } from "fs/promises";
+import { readFile, open } from "fs/promises";
 import { randomUUID } from "crypto";
 import type {
   AgentAdapter,


### PR DESCRIPTION
## Summary
- Consolidated two separate `import ... from "fs/promises"` statements (lines 2-3) into a single `import { readFile, open } from "fs/promises";` in `src/adapters/agent/opencode.ts`
- Purely cosmetic style cleanup with no logic changes

## Related Issue
Closes #29

## Changes
- `src/adapters/agent/opencode.ts`: merged `import { readFile } from "fs/promises"` and `import { open } from "fs/promises"` into one combined import statement

## Test Plan
- Build passes: `npm run build` exits 0 with no errors
- All 76 tests pass across 11 test files

🤖 Generated by oflow dev-workflow