### PR TITLE
feat: Opencode agent adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,15 @@ Then open `.env` and set at minimum `OFLOW_GITHUB_TOKEN` and `OFLOW_GITHUB_REPO`
 | `OFLOW_DEFAULT_WORKFLOW` | No | `dev-workflow` | Skill workflow name invoked at the start of each Claude Code session. |
 | `OFLOW_POLL_INTERVAL_SECONDS` | No | `60` | How often (in seconds) the daemon polls GitHub for new ready tasks. |
 
+### Agents
+
+oflow supports two agent adapters, selected via the `OFLOW_AGENT` environment variable:
+
+- **`claude-code`** (default) — spawns a Claude Code (`claude`) session for each task. Each skill step dispatches a native subagent, so steps run in isolated contexts with full tool access.
+- **`opencode`** — spawns an `opencode` session for each task. Because opencode does not support native subagent dispatch, all skill steps execute sequentially within a single session context. This means the entire dev-workflow runs in one continuous conversation rather than per-step subagents.
+
+Set `OFLOW_AGENT=opencode` in your `.env` file to use the opencode adapter.
+
 ## Usage
 
 ### Daemon mode

--- a/src/adapters/agent/opencode.test.ts
+++ b/src/adapters/agent/opencode.test.ts
@@ -1,0 +1,354 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Mock child_process at module level
+vi.mock("child_process", () => {
+  const mockStdout = { pipe: vi.fn() };
+  const mockStderr = { pipe: vi.fn() };
+  const mockProcess = {
+    pid: 99999,
+    stdout: mockStdout,
+    stderr: mockStderr,
+    on: vi.fn(),
+    unref: vi.fn(),
+  };
+  return {
+    spawn: vi.fn(() => mockProcess),
+  };
+});
+
+// Mock fs/promises to return a fake FileHandle (avoids unclosed fd GC errors)
+const mockLogFd = {
+  createWriteStream: vi.fn(() => ({ write: vi.fn(), end: vi.fn() })),
+  close: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs/promises")>();
+  return {
+    ...actual,
+    open: vi.fn(async (_path: string, _flags: string) => mockLogFd),
+  };
+});
+
+import { spawn as spawnMock } from "child_process";
+import { OpencodeAdapter } from "./opencode.js";
+
+describe("OpencodeAdapter", () => {
+  let tmpDir: string;
+  let adapter: OpencodeAdapter;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockLogFd.createWriteStream.mockReturnValue({ write: vi.fn(), end: vi.fn() });
+    mockLogFd.close.mockResolvedValue(undefined);
+    tmpDir = await mkdtemp(join(tmpdir(), "oflow-opencode-test-"));
+    adapter = new OpencodeAdapter();
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("spawn", () => {
+    it("spawns a process and returns a session", async () => {
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+
+      await writeFile(skillFile, "# Skill content");
+      await writeFile(taskContextFile, JSON.stringify({ id: "42" }));
+      await writeFile(logFile, "");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 99999,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn(),
+        unref: vi.fn(),
+      });
+
+      const session = await adapter.spawn({
+        skill: skillFile,
+        taskContextFile,
+        repoPath: tmpDir,
+        taskId: "42",
+        logFile,
+      });
+
+      expect(session.pid).toBe(99999);
+      expect(session.taskId).toBe("42");
+      expect(session.logFile).toBe(logFile);
+      expect(session.id).toBeTruthy();
+      expect(spawnMock).toHaveBeenCalled();
+    });
+
+    it("spawns opencode with run --prompt args", async () => {
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+      await writeFile(skillFile, "# Skill");
+      await writeFile(taskContextFile, "{}");
+      await writeFile(logFile, "");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 99999,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn(),
+        unref: vi.fn(),
+      });
+
+      await adapter.spawn({ skill: skillFile, taskContextFile, repoPath: tmpDir, taskId: "42", logFile });
+
+      const spawnCall = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0];
+      expect(spawnCall[0]).toBe("opencode");
+      expect(spawnCall[1]).toContain("run");
+      expect(spawnCall[1]).toContain("--prompt");
+    });
+
+    it("sets OFLOW_CURRENT_TASK_ID env var for child process", async () => {
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+
+      await writeFile(skillFile, "# Skill");
+      await writeFile(taskContextFile, "{}");
+      await writeFile(logFile, "");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 12345,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn(),
+        unref: vi.fn(),
+      });
+
+      await adapter.spawn({
+        skill: skillFile,
+        taskContextFile,
+        repoPath: tmpDir,
+        taskId: "42",
+        logFile,
+      });
+
+      const spawnCall = (spawnMock as ReturnType<typeof vi.fn>).mock.calls[0];
+      const spawnOptions = spawnCall[2] as { env?: Record<string, string> };
+      expect(spawnOptions.env?.OFLOW_CURRENT_TASK_ID).toBe("42");
+    });
+  });
+
+  describe("getStatus", () => {
+    it("returns completed from exitCodes map when exit code is 0", async () => {
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+      await writeFile(skillFile, "# Skill");
+      await writeFile(taskContextFile, "{}");
+      await writeFile(logFile, "");
+
+      let closeHandler: ((code: number | null) => void) | undefined;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 99999,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn((event: string, handler: (code: number | null) => void) => {
+          if (event === "close") closeHandler = handler;
+        }),
+        unref: vi.fn(),
+      });
+
+      const session = await adapter.spawn({
+        skill: skillFile,
+        taskContextFile,
+        repoPath: tmpDir,
+        taskId: "42",
+        logFile,
+      });
+
+      // Simulate process exit with code 0
+      closeHandler?.(0);
+
+      const status = await adapter.getStatus(session.id);
+      expect(status).toBe("completed");
+    });
+
+    it("returns failed from exitCodes map when exit code is non-zero", async () => {
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+      await writeFile(skillFile, "# Skill");
+      await writeFile(taskContextFile, "{}");
+      await writeFile(logFile, "");
+
+      let closeHandler: ((code: number | null) => void) | undefined;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 99999,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn((event: string, handler: (code: number | null) => void) => {
+          if (event === "close") closeHandler = handler;
+        }),
+        unref: vi.fn(),
+      });
+
+      const session = await adapter.spawn({
+        skill: skillFile,
+        taskContextFile,
+        repoPath: tmpDir,
+        taskId: "42",
+        logFile,
+      });
+
+      // Simulate process exit with non-zero code
+      closeHandler?.(1);
+
+      const status = await adapter.getStatus(session.id);
+      expect(status).toBe("failed");
+    });
+
+    it("returns running when process is alive (no exit code yet)", async () => {
+      const killSpy = vi.spyOn(process, "kill").mockReturnValue(true);
+
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+      await writeFile(skillFile, "# Skill");
+      await writeFile(taskContextFile, "{}");
+      await writeFile(logFile, "");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 99999,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn(),
+        unref: vi.fn(),
+      });
+
+      const session = await adapter.spawn({
+        skill: skillFile,
+        taskContextFile,
+        repoPath: tmpDir,
+        taskId: "42",
+        logFile,
+      });
+
+      const status = await adapter.getStatus(session.id);
+      expect(status).toBe("running");
+      killSpy.mockRestore();
+    });
+
+    it("returns completed when process is not running (ESRCH, no exit code)", async () => {
+      const killSpy = vi.spyOn(process, "kill").mockImplementation(() => {
+        const err = new Error("ESRCH") as NodeJS.ErrnoException;
+        err.code = "ESRCH";
+        throw err;
+      });
+
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+      await writeFile(skillFile, "# Skill");
+      await writeFile(taskContextFile, "{}");
+      await writeFile(logFile, "");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 99999,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn(),
+        unref: vi.fn(),
+      });
+
+      const session = await adapter.spawn({
+        skill: skillFile,
+        taskContextFile,
+        repoPath: tmpDir,
+        taskId: "42",
+        logFile,
+      });
+
+      const status = await adapter.getStatus(session.id);
+      expect(status).toBe("completed");
+      killSpy.mockRestore();
+    });
+  });
+
+  describe("waitForCompletion", () => {
+    it("returns actual exit code from exitCodes map", async () => {
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+      await writeFile(skillFile, "# Skill");
+      await writeFile(taskContextFile, "{}");
+      await writeFile(logFile, "");
+
+      let closeHandler: ((code: number | null) => void) | undefined;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 99999,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn((event: string, handler: (code: number | null) => void) => {
+          if (event === "close") closeHandler = handler;
+        }),
+        unref: vi.fn(),
+      });
+
+      const session = await adapter.spawn({
+        skill: skillFile,
+        taskContextFile,
+        repoPath: tmpDir,
+        taskId: "42",
+        logFile,
+      });
+
+      // Simulate process exit with code 42 (non-zero)
+      closeHandler?.(42);
+
+      const result = await adapter.waitForCompletion(session.id);
+      expect(result.exitCode).toBe(42);
+      expect(result.status).toBe("failed");
+    });
+  });
+
+  describe("getLogs", () => {
+    it("reads logFile content", async () => {
+      const skillFile = join(tmpDir, "skill.md");
+      const taskContextFile = join(tmpDir, "task-context.json");
+      const logFile = join(tmpDir, "run.log");
+      await writeFile(skillFile, "# Skill");
+      await writeFile(taskContextFile, "{}");
+      await writeFile(logFile, "agent output here");
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (spawnMock as any).mockReturnValue({
+        pid: 99999,
+        stdout: { pipe: vi.fn() },
+        stderr: { pipe: vi.fn() },
+        on: vi.fn(),
+        unref: vi.fn(),
+      });
+
+      const session = await adapter.spawn({
+        skill: skillFile,
+        taskContextFile,
+        repoPath: tmpDir,
+        taskId: "42",
+        logFile,
+      });
+
+      const logs = await adapter.getLogs(session.id);
+      expect(logs).toBe("agent output here");
+    });
+  });
+});

--- a/src/adapters/agent/opencode.ts
+++ b/src/adapters/agent/opencode.ts
@@ -18,6 +18,7 @@ import type {
  */
 export class OpencodeAdapter implements AgentAdapter {
   private sessions: Map<string, Session> = new Map();
+  private exitCodes: Map<string, number> = new Map();
 
   async spawn(options: SpawnOptions): Promise<Session> {
     const { skill, taskContextFile, repoPath, taskId, logFile } = options;
@@ -50,6 +51,12 @@ export class OpencodeAdapter implements AgentAdapter {
       startedAt: new Date(),
     };
 
+    // Track exit code so getStatus can report failed vs completed accurately
+    child.on("close", (code) => {
+      this.exitCodes.set(session.id, code ?? 1);
+      logFd.close();
+    });
+
     this.sessions.set(session.id, session);
     return session;
   }
@@ -58,12 +65,17 @@ export class OpencodeAdapter implements AgentAdapter {
     const session = this.sessions.get(sessionId);
     if (!session) return "failed";
 
+    if (this.exitCodes.has(sessionId)) {
+      return this.exitCodes.get(sessionId) === 0 ? "completed" : "failed";
+    }
+
     try {
       process.kill(session.pid, 0);
       return "running";
     } catch (err) {
       const error = err as NodeJS.ErrnoException;
       if (error.code === "ESRCH") {
+        // Process gone but no exit code recorded yet — treat as completed
         return "completed";
       }
       return "failed";
@@ -82,9 +94,10 @@ export class OpencodeAdapter implements AgentAdapter {
         const status = await this.getStatus(sessionId);
         if (status !== "running") {
           clearInterval(checkInterval);
+          const exitCode = this.exitCodes.get(sessionId) ?? (status === "completed" ? 0 : 1);
           resolve({
             status: status === "completed" ? "completed" : "failed",
-            exitCode: status === "completed" ? 0 : 1,
+            exitCode,
             duration: Date.now() - startTime,
           });
         }


### PR DESCRIPTION
## Summary
- Upgrades `OpencodeAdapter` stub to a fully working implementation with exit code tracking (`exitCodes` Map + `close` handler)
- Adds 9 unit tests in `src/adapters/agent/opencode.test.ts` covering all adapter methods (spawn, getStatus, waitForCompletion, getLogs)
- Documents `OFLOW_AGENT=opencode` env var and single-context limitation in README

## Related Issue
Closes #2

## Changes
- `src/adapters/agent/opencode.ts`: added `exitCodes` Map field, `child.on("close", ...)` handler that tracks exit code and closes `logFd`, updated `getStatus` to check the map before `process.kill(0)` probe, updated `waitForCompletion` to use actual tracked exit code
- `src/adapters/agent/opencode.test.ts`: new file with 9 tests mirroring `claude-code.test.ts` structure
- `README.md`: added "### Agents" subsection documenting both adapters and the opencode single-context limitation

## Test Plan
- Run `npm test` — 112 tests pass across 13 test files (9 new tests for OpencodeAdapter)
- Set `OFLOW_AGENT=opencode` in `.env` and run `oflow run` to verify opencode adapter is selected at startup

🤖 Generated by oflow dev-workflow