### PR TITLE
fix: restore oflow-ready label on task failure instead of oflow-done

### DIFF
--- a/src/adapters/board/github.test.ts
+++ b/src/adapters/board/github.test.ts
@@ -233,6 +233,24 @@ describe("GitHubBoardAdapter", () => {
       );
     });
 
+    it("restores oflow-ready label and removes oflow-in-progress when status is failed", async () => {
+      mock.issues.createComment.mockResolvedValue({});
+      mock.issues.addLabels.mockResolvedValue({});
+      mock.issues.removeLabel.mockResolvedValue({});
+      mock.issues.get.mockResolvedValue({
+        data: makeIssue({ labels: [{ name: "oflow-in-progress" }] }),
+      });
+
+      await adapter.updateTask("42", { status: "failed" });
+
+      expect(mock.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({ labels: ["oflow-ready"] })
+      );
+      expect(mock.issues.removeLabel).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "oflow-in-progress" })
+      );
+    });
+
     it("does not throw when removeLabel returns 404 (label already removed)", async () => {
       mock.issues.addLabels.mockResolvedValue({});
       mock.issues.removeLabel.mockRejectedValue(

--- a/src/adapters/board/github.ts
+++ b/src/adapters/board/github.ts
@@ -102,7 +102,7 @@ export class GitHubBoardAdapter implements BoardAdapter {
       const labelMap: Record<string, string> = {
         "in-progress": this.config.taskInProgressLabel,
         done: this.config.taskDoneLabel,
-        failed: this.config.taskDoneLabel,
+        failed: this.config.taskLabel,
       };
 
       const removeMap: Record<string, string> = {

--- a/src/adapters/board/gitlab.test.ts
+++ b/src/adapters/board/gitlab.test.ts
@@ -178,14 +178,14 @@ describe("GitLabBoardAdapter", () => {
       expect(putBody.get("remove_labels")).toBe("oflow-in-progress");
     });
 
-    it("swaps labels when status is failed", async () => {
+    it("restores oflow-ready and removes oflow-in-progress when status is failed", async () => {
       const fetchMock = mockFetch([{ status: 200, body: makeIssue() }]);
       vi.stubGlobal("fetch", fetchMock);
 
       await adapter.updateTask("42", { status: "failed" });
 
       const putBody = new URLSearchParams((fetchMock.mock.calls[0][1] as RequestInit).body as string);
-      expect(putBody.get("add_labels")).toBe("oflow-done");
+      expect(putBody.get("add_labels")).toBe("oflow-ready");
       expect(putBody.get("remove_labels")).toBe("oflow-in-progress");
     });
 

--- a/src/adapters/board/gitlab.ts
+++ b/src/adapters/board/gitlab.ts
@@ -111,7 +111,7 @@ export class GitLabBoardAdapter implements BoardAdapter {
       const labelMap: Record<string, string> = {
         "in-progress": this.config.taskInProgressLabel,
         done: this.config.taskDoneLabel,
-        failed: this.config.taskDoneLabel,
+        failed: this.config.taskLabel,
       };
 
       const removeMap: Record<string, string> = {


### PR DESCRIPTION
## Summary
- Bug: when an agent fails (e.g. rate limit), the task was incorrectly marked with `oflow-done` label and left stranded in ToDo
- Fix: changed `labelMap["failed"]` in both `github.ts` and `gitlab.ts` from `taskDoneLabel` (`oflow-done`) to `taskLabel` (`oflow-ready`), so failed tasks are re-queued
- Tests updated in both board adapter test files to verify the corrected label assignment

## Related Issue
Closes #82

## Changes
- `src/board/github.ts`: `labelMap["failed"]` now maps to `taskLabel` (`oflow-ready`) instead of `taskDoneLabel` (`oflow-done`)
- `src/board/gitlab.ts`: same fix applied for GitLab board adapter
- Test files updated to assert failed tasks get `oflow-ready` label
- `run.ts` already calls `updateTask` with status `"failed"` on non-zero agent exit — no daemon changes needed

## Test Plan
- Run the board adapter tests to verify failed tasks are re-queued with `oflow-ready`
- Simulate an agent failure (e.g. rate limit) and confirm the task moves back to the queue instead of being marked done

🤖 Generated by oflow dev-workflow