### PR TITLE
refactor: remove process.exit from validateArtifactCmd

### DIFF
--- a/src/cli/commands/validate.test.ts
+++ b/src/cli/commands/validate.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { validateArtifactCmd } from "./validate.js";
+
+vi.mock("fs/promises");
+vi.mock("../../state/validator.js");
+
+import { readFile } from "fs/promises";
+import { validateArtifact } from "../../state/validator.js";
+
+const mockReadFile = vi.mocked(readFile);
+const mockValidateArtifact = vi.mocked(validateArtifact);
+
+describe("validateArtifactCmd", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Default: OFLOW_CURRENT_TASK_ID is set so getCurrentTaskId doesn't hit the filesystem
+    process.env.OFLOW_CURRENT_TASK_ID = "42";
+  });
+
+  describe("file-not-found case", () => {
+    it("throws when the artifact file does not exist", async () => {
+      mockReadFile.mockRejectedValue(new Error("ENOENT: no such file or directory"));
+
+      await expect(validateArtifactCmd("plan", "/repo")).rejects.toThrow(
+        /artifact file not found/
+      );
+    });
+
+    it("throws with a non-existent artifact name", async () => {
+      mockReadFile.mockRejectedValue(new Error("ENOENT"));
+
+      await expect(validateArtifactCmd("nonexistent-artifact", "/repo")).rejects.toThrow(
+        /artifact file not found/
+      );
+    });
+
+    it("throws with a non-existent task ID (no current file, no env var)", async () => {
+      delete process.env.OFLOW_CURRENT_TASK_ID;
+      // First readFile call is for .oflow/current, second would be for the artifact
+      mockReadFile.mockRejectedValueOnce(new Error("ENOENT: .oflow/current not found"));
+
+      await expect(validateArtifactCmd("plan", "/repo")).rejects.toThrow(
+        /No current task ID found/
+      );
+    });
+  });
+
+  describe("validation failure case", () => {
+    it("throws when the artifact fails schema validation", async () => {
+      mockReadFile.mockResolvedValue("---\nartifact: plan\n---\n" as never);
+      mockValidateArtifact.mockReturnValue({
+        success: false,
+        errors: ["field: required field missing"],
+      });
+
+      await expect(validateArtifactCmd("plan", "/repo")).rejects.toThrow(
+        /plan validation failed/
+      );
+    });
+
+    it("throws for implementation-1 when validation fails", async () => {
+      mockReadFile.mockResolvedValue("---\nartifact: implementation\n---\n" as never);
+      mockValidateArtifact.mockReturnValue({
+        success: false,
+        errors: ["status: invalid value"],
+      });
+
+      await expect(validateArtifactCmd("implementation-1", "/repo")).rejects.toThrow(
+        /implementation-1 validation failed/
+      );
+    });
+  });
+
+  describe("happy path", () => {
+    it("resolves without throwing when the artifact is valid", async () => {
+      mockReadFile.mockResolvedValue("---\nartifact: plan\n---\n" as never);
+      mockValidateArtifact.mockReturnValue({ success: true, data: {} });
+
+      await expect(validateArtifactCmd("plan", "/repo")).resolves.toBeUndefined();
+    });
+
+    it("calls validateArtifact with the artifact name and file content", async () => {
+      const content = "---\nartifact: exploration\n---\nsome body\n";
+      mockReadFile.mockResolvedValue(content as never);
+      mockValidateArtifact.mockReturnValue({ success: true, data: {} });
+
+      await validateArtifactCmd("exploration", "/repo");
+
+      expect(mockValidateArtifact).toHaveBeenCalledWith("exploration", content);
+    });
+
+    it("resolves for implementation-N artifact names", async () => {
+      mockReadFile.mockResolvedValue("---\nartifact: implementation\n---\n" as never);
+      mockValidateArtifact.mockReturnValue({ success: true, data: {} });
+
+      await expect(validateArtifactCmd("implementation-2", "/repo")).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -28,20 +28,16 @@ export async function validateArtifactCmd(
   try {
     content = await readFile(artifactFile, "utf-8");
   } catch {
-    console.error(`Error: artifact file not found: ${artifactFile}`);
-    process.exit(1);
+    throw new Error(`artifact file not found: ${artifactFile}`);
   }
 
   const result = validateArtifact(artifactName, content);
 
   if (result.success) {
     console.log(`✓ ${artifactName} is valid`);
-    process.exit(0);
+    return;
   } else {
-    console.error(`✗ ${artifactName} validation failed:`);
-    for (const error of result.errors) {
-      console.error(`  - ${error}`);
-    }
-    process.exit(1);
+    const errorLines = result.errors.map((e) => `  - ${e}`).join("\n");
+    throw new Error(`${artifactName} validation failed:\n${errorLines}`);
   }
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -105,7 +105,12 @@ program
   .description("Validate an artifact against its schema (exits 0/1)")
   .action(async (artifactName: string) => {
     const { validateArtifactCmd } = await import("./commands/validate.js");
-    await validateArtifactCmd(artifactName, resolve("."));
+    try {
+      await validateArtifactCmd(artifactName, resolve("."));
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
   });
 
 // run command


### PR DESCRIPTION
## Summary
- Replace direct `process.exit()` calls in `validateArtifactCmd` with thrown `Error` instances, enabling unit testing without mocking `process.exit`
- Move `process.exit(1)` to the CLI entry point (`src/cli/index.ts`) inside a try/catch wrapper
- Add 8 unit tests in `validate.test.ts` covering all code paths (file not found, validation failure, success)

## Related Issue
Closes #25

## Changes
- `src/cli/commands/validate.ts`: replaced `process.exit()` calls with `throw new Error(...)` for file-not-found and validation-failure cases; removed `console.error` calls to avoid double output; kept `console.log` for success
- `src/cli/index.ts`: wrapped `validateArtifactCmd` call in try/catch that logs the error message and calls `process.exit(1)`
- `src/cli/commands/validate.test.ts`: new file with 8 unit tests proving testability without `process.exit` mocking

## Test Plan
- Run `npm test` — all 146 tests pass including the 8 new unit tests in `validate.test.ts`
- Verify CLI behavior is unchanged: `oflow validate` still exits with code 1 on error and 0 on success

🤖 Generated by oflow dev-workflow