### PR TITLE
refactor: extract duplicate getCurrentTaskId to shared utility

### DIFF
--- a/src/cli/commands/state.ts
+++ b/src/cli/commands/state.ts
@@ -1,21 +1,5 @@
-import { readFile } from "fs/promises";
-import { join } from "path";
 import { StateManager } from "../../state/manager.js";
-
-async function getCurrentTaskId(repoPath: string): Promise<string> {
-  const envTaskId = process.env.OFLOW_CURRENT_TASK_ID;
-  if (envTaskId) return envTaskId;
-
-  const currentFile = join(repoPath, ".oflow", "current");
-  try {
-    const content = await readFile(currentFile, "utf-8");
-    return content.trim();
-  } catch {
-    throw new Error(
-      "No current task ID found. Set OFLOW_CURRENT_TASK_ID env var or create .oflow/current file."
-    );
-  }
-}
+import { getCurrentTaskId } from "../utils.js";
 
 export async function stateInit(taskId: string, repoPath: string): Promise<void> {
   const manager = new StateManager(repoPath);

--- a/src/cli/commands/validate.ts
+++ b/src/cli/commands/validate.ts
@@ -1,21 +1,7 @@
 import { readFile } from "fs/promises";
 import { join } from "path";
 import { validateArtifact } from "../../state/validator.js";
-
-async function getCurrentTaskId(repoPath: string): Promise<string> {
-  const envTaskId = process.env.OFLOW_CURRENT_TASK_ID;
-  if (envTaskId) return envTaskId;
-
-  const currentFile = join(repoPath, ".oflow", "current");
-  try {
-    const content = await readFile(currentFile, "utf-8");
-    return content.trim();
-  } catch {
-    throw new Error(
-      "No current task ID found. Set OFLOW_CURRENT_TASK_ID env var or create .oflow/current file."
-    );
-  }
-}
+import { getCurrentTaskId } from "../utils.js";
 
 export async function validateArtifactCmd(
   artifactName: string,

--- a/src/cli/utils.test.ts
+++ b/src/cli/utils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, mkdir } from "fs/promises";
+import { join } from "path";
+import { tmpdir } from "os";
+import { rmSync } from "fs";
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), "oflow-utils-test-"));
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.OFLOW_CURRENT_TASK_ID;
+});
+
+describe("getCurrentTaskId", () => {
+  it("returns the env var when OFLOW_CURRENT_TASK_ID is set", async () => {
+    const { getCurrentTaskId } = await import("./utils.js");
+    process.env.OFLOW_CURRENT_TASK_ID = "42";
+    const result = await getCurrentTaskId(tmpDir);
+    expect(result).toBe("42");
+  });
+
+  it("reads from .oflow/current file when env var is not set", async () => {
+    const { getCurrentTaskId } = await import("./utils.js");
+    const oflowDir = join(tmpDir, ".oflow");
+    await mkdir(oflowDir);
+    await writeFile(join(oflowDir, "current"), "  99  \n");
+    const result = await getCurrentTaskId(tmpDir);
+    expect(result).toBe("99");
+  });
+
+  it("throws when env var is absent and .oflow/current does not exist", async () => {
+    const { getCurrentTaskId } = await import("./utils.js");
+    await expect(getCurrentTaskId(tmpDir)).rejects.toThrow(
+      "No current task ID found"
+    );
+  });
+});

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,0 +1,17 @@
+import { readFile } from "fs/promises";
+import { join } from "path";
+
+export async function getCurrentTaskId(repoPath: string): Promise<string> {
+  const envTaskId = process.env.OFLOW_CURRENT_TASK_ID;
+  if (envTaskId) return envTaskId;
+
+  const currentFile = join(repoPath, ".oflow", "current");
+  try {
+    const content = await readFile(currentFile, "utf-8");
+    return content.trim();
+  } catch {
+    throw new Error(
+      "No current task ID found. Set OFLOW_CURRENT_TASK_ID env var or create .oflow/current file."
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- Extract the byte-for-byte duplicate `getCurrentTaskId` function from `state.ts` and `validate.ts` into a new shared `src/cli/utils.ts`
- Update both command files to import `getCurrentTaskId` from `../utils.js`
- Add `src/cli/utils.test.ts` with 3 unit tests covering all branches of `getCurrentTaskId`

## Related Issue
Closes #21

## Changes
- New file: `src/cli/utils.ts` — exports `getCurrentTaskId(repoPath)`
- New file: `src/cli/utils.test.ts` — unit tests for the utility
- `src/cli/commands/state.ts` — removed local `getCurrentTaskId`, now imports from utils
- `src/cli/commands/validate.ts` — removed local `getCurrentTaskId`, now imports from utils

## Test Plan
- All 144 existing tests pass: `npm test`
- 3 new unit tests in `src/cli/utils.test.ts` cover: env var present, `.oflow/current` file present, and error when neither exists

🤖 Generated by oflow dev-workflow