### PR TITLE
fix: remove dead agentModel config field and OFLOW_AGENT_MODEL env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Then open `.env` and set at minimum `OFLOW_GITHUB_TOKEN` and `OFLOW_GITHUB_REPO`
 | `OFLOW_TASK_IN_PROGRESS_LABEL` | No | `oflow-in-progress` | Label applied to an issue while a session is running. |
 | `OFLOW_TASK_DONE_LABEL` | No | `oflow-done` | Label applied to an issue after the session completes. |
 | `OFLOW_AGENT` | No | `claude-code` | Agent adapter to use for executing tasks. |
-| `OFLOW_AGENT_MODEL` | No | `claude-opus-4-6` | Model passed to the agent when spawning a session. |
 | `OFLOW_MAX_CONCURRENT_TASKS` | No | `1` | Maximum number of tasks that can run in parallel. |
 | `OFLOW_DEFAULT_WORKFLOW` | No | `dev-workflow` | Skill workflow name invoked at the start of each Claude Code session. |
 | `OFLOW_POLL_INTERVAL_SECONDS` | No | `60` | How often (in seconds) the daemon polls GitHub for new ready tasks. |
@@ -63,6 +62,11 @@ oflow supports two agent adapters, selected via the `OFLOW_AGENT` environment va
 - **`opencode`** — spawns an `opencode` session for each task. Because opencode does not support native subagent dispatch, all skill steps execute sequentially within a single session context. This means the entire dev-workflow runs in one continuous conversation rather than per-step subagents.
 
 Set `OFLOW_AGENT=opencode` in your `.env` file to use the opencode adapter.
+
+Model selection is not managed by oflow — it is delegated to each agent's own configuration:
+
+- **`claude-code`**: the model is controlled via Claude Code's own configuration. Use `claude model set <model>` or set the `model` field in `~/.claude/settings.json`.
+- **`opencode`**: model selection is opencode's own concern, configured in opencode's settings.
 
 ## Usage
 

--- a/src/adapters/board/github.test.ts
+++ b/src/adapters/board/github.test.ts
@@ -40,7 +40,6 @@ const defaultConfig = {
   taskInProgressLabel: "oflow-in-progress",
   taskDoneLabel: "oflow-done",
   agent: "claude-code",
-  agentModel: "claude-opus-4-6",
   maxConcurrentTasks: 1,
   defaultWorkflow: "dev-workflow",
   pollIntervalSeconds: 60,

--- a/src/adapters/board/gitlab.test.ts
+++ b/src/adapters/board/gitlab.test.ts
@@ -11,7 +11,6 @@ const defaultConfig = {
   taskDoneLabel: "oflow-done",
   taskFailedLabel: "oflow-failed",
   agent: "claude-code",
-  agentModel: "claude-opus-4-6",
   maxConcurrentTasks: 1,
   defaultWorkflow: "dev-workflow",
   pollIntervalSeconds: 60,

--- a/src/cli/commands/run.ts
+++ b/src/cli/commands/run.ts
@@ -121,7 +121,7 @@ export async function runDaemon(repoPath: string, label?: string): Promise<void>
 
   log(`oflow daemon started`);
   log(`  board:  ${config.board} / ${config.githubRepo}`);
-  log(`  agent:  ${config.agent} (${config.agentModel})`);
+  log(`  agent:  ${config.agent}`);
   log(`  label:  ${label ?? config.taskLabel}`);
   log(`  slots:  ${config.maxConcurrentTasks}`);
   log(`  poll:   every ${config.pollIntervalSeconds}s`);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -7,7 +7,6 @@ const baseSchema = z.object({
   OFLOW_TASK_IN_PROGRESS_LABEL: z.string().default("oflow-in-progress"),
   OFLOW_TASK_DONE_LABEL: z.string().default("oflow-done"),
   OFLOW_AGENT: z.string().default("claude-code"),
-  OFLOW_AGENT_MODEL: z.string().default("claude-opus-4-6"),
   OFLOW_MAX_CONCURRENT_TASKS: z
     .string()
     .default("1")
@@ -68,7 +67,6 @@ export function loadConfig(): Config {
       taskInProgressLabel: base.OFLOW_TASK_IN_PROGRESS_LABEL,
       taskDoneLabel: base.OFLOW_TASK_DONE_LABEL,
       agent: base.OFLOW_AGENT,
-      agentModel: base.OFLOW_AGENT_MODEL,
       maxConcurrentTasks: base.OFLOW_MAX_CONCURRENT_TASKS,
       defaultWorkflow: base.OFLOW_DEFAULT_WORKFLOW,
       pollIntervalSeconds: base.OFLOW_POLL_INTERVAL_SECONDS,
@@ -93,7 +91,6 @@ export function loadConfig(): Config {
       taskInProgressLabel: base.OFLOW_TASK_IN_PROGRESS_LABEL,
       taskDoneLabel: base.OFLOW_TASK_DONE_LABEL,
       agent: base.OFLOW_AGENT,
-      agentModel: base.OFLOW_AGENT_MODEL,
       maxConcurrentTasks: base.OFLOW_MAX_CONCURRENT_TASKS,
       defaultWorkflow: base.OFLOW_DEFAULT_WORKFLOW,
       pollIntervalSeconds: base.OFLOW_POLL_INTERVAL_SECONDS,
@@ -107,7 +104,6 @@ export function loadConfig(): Config {
     taskInProgressLabel: base.OFLOW_TASK_IN_PROGRESS_LABEL,
     taskDoneLabel: base.OFLOW_TASK_DONE_LABEL,
     agent: base.OFLOW_AGENT,
-    agentModel: base.OFLOW_AGENT_MODEL,
     maxConcurrentTasks: base.OFLOW_MAX_CONCURRENT_TASKS,
     defaultWorkflow: base.OFLOW_DEFAULT_WORKFLOW,
     pollIntervalSeconds: base.OFLOW_POLL_INTERVAL_SECONDS,

--- a/src/config/types.ts
+++ b/src/config/types.ts
@@ -9,7 +9,6 @@ export interface Config {
   taskInProgressLabel: string;
   taskDoneLabel: string;
   agent: string;
-  agentModel: string;
   maxConcurrentTasks: number;
   defaultWorkflow: string;
   pollIntervalSeconds: number;


### PR DESCRIPTION
## Summary
- Removes the `agentModel` field from the `Config` type, zod loader schema, and all three return paths in `loadConfig()`
- Operators who set `OFLOW_AGENT_MODEL` were seeing no effect; the env var is now removed entirely
- Adds README documentation explaining how model selection actually works for `claude-code` and `opencode` adapters

## Related Issue
Closes #22

## Changes
- `src/config/types.ts`: Remove `agentModel: string` from the `Config` interface
- `src/config/loader.ts`: Remove `OFLOW_AGENT_MODEL` from the zod schema and all three `loadConfig()` return branches
- `src/cli/commands/run.ts`: Simplify startup log line (drop the parenthetical model reference)
- `src/adapters/board/github.test.ts` and `gitlab.test.ts`: Remove `agentModel` from `defaultConfig` fixtures
- `README.md`: Remove `OFLOW_AGENT_MODEL` from env vars table; add model-selection explanation in the Agents section

## Test Plan
- Run `npm test` — all 187 tests should pass with 0 failures
- Verify TypeScript compiles cleanly: `npx tsc --noEmit`
- Confirm `OFLOW_AGENT_MODEL` is no longer referenced anywhere in `src/`

🤖 Generated by oflow dev-workflow